### PR TITLE
add available regions check for dataform and vertex-ai pipelines

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -24,6 +24,7 @@ module "data_store" {
   source = "./modules/data-store"
 
   google_default_region = var.google_default_region
+  dataform_region       = var.dataform_region
 
   source_ga4_export_project_id = var.source_ga4_export_project_id
   source_ga4_export_dataset    = var.source_ga4_export_dataset

--- a/infrastructure/terraform/modules/data-store/dataform.tf
+++ b/infrastructure/terraform/modules/data-store/dataform.tf
@@ -12,11 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  dataform_available_locations = [
+    "asia-east1",
+    "asia-northeast1",
+    "asia-south1",
+    "asia-southeast1",
+    "australia-southeast1",
+    "europe-west1",
+    "europe-west2",
+    "europe-west3",
+    "europe-west4",
+    "europe-west6",
+    "southamerica-east1",
+    "us-east1",
+    "us-central1",
+    "us-west1",
+  ]
+  dataform_derived_region = var.dataform_region != "" ? var.dataform_region : var.google_default_region
+}
 resource "google_dataform_repository" "marketing-analytics" {
   provider = google-beta
   name     = "marketing-analytics"
   project  = data.google_project.data_processing.project_id
-  region   = var.google_default_region
+  region   = local.dataform_derived_region
+
+  lifecycle {
+    precondition {
+      condition     = contains(local.dataform_available_locations, local.dataform_derived_region)
+      error_message = "Dataform is not available in your default region: ${var.google_default_region}.\nSet 'dataform_region' variable to a valid Dataform location, see https://cloud.google.com/dataform/docs/locations."
+    }
+  }
 
   git_remote_settings {
     url                                 = var.dataform_github_repo

--- a/infrastructure/terraform/modules/data-store/variables.tf
+++ b/infrastructure/terraform/modules/data-store/variables.tf
@@ -119,3 +119,8 @@ variable "source_ads_export_data" {
     table_suffix = string
   }))
 }
+
+variable "dataform_region" {
+  description = "Specify dataform region when dataform is not available in the default cloud region of choice"
+  type        = string
+}

--- a/infrastructure/terraform/modules/pipelines/pipelines.tf
+++ b/infrastructure/terraform/modules/pipelines/pipelines.tf
@@ -76,11 +76,41 @@ resource "google_storage_bucket" "pipelines_bucket" {
   uniform_bucket_level_access = true
   force_destroy               = false
   lifecycle {
-    ignore_changes = all
+    ignore_changes  = all
     prevent_destroy = false ##true
   }
 }
 
+locals {
+  vertex_pipelines_available_locations = [
+    "asia-east1",
+    "asia-east2",
+    "asia-northeast1",
+    "asia-northeast3",
+    "asia-south1",
+    "asia-southeast1",
+    "asia-southeast2",
+    "europe-central2",
+    "europe-west1",
+    "europe-west2",
+    "europe-west3",
+    "europe-west4",
+    "europe-west6",
+    "europe-west9",
+    "me-west1",
+    "northamerica-northeast1",
+    "northamerica-northeast2",
+    "southamerica-east1",
+    "us-central1",
+    "us-east1",
+    "us-east4",
+    "us-south1",
+    "us-west1",
+    "us-west2",
+    "us-west3",
+    "us-west4",
+  ]
+}
 
 resource "google_artifact_registry_repository" "pipelines-repo" {
   project       = module.project_services.project_id
@@ -88,6 +118,12 @@ resource "google_artifact_registry_repository" "pipelines-repo" {
   repository_id = local.artifact_registry_vars.pipelines_repo.name
   description   = "Pipelines Repository"
   format        = "KFP"
+  lifecycle {
+    precondition {
+      condition     = contains(local.vertex_pipelines_available_locations, local.artifact_registry_vars.pipelines_repo.region)
+      error_message = "Vertex AI Pipelines is not available in your default region: ${local.artifact_registry_vars.pipelines_repo.region}.\nSet 'google_default_region' variable to a valid Vertex AI Pipelines location, see https://cloud.google.com/vertex-ai/docs/general/locations."
+    }
+  }
 }
 
 

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -38,6 +38,12 @@ variable "google_default_region" {
   type        = string
 }
 
+variable "dataform_region" {
+  description = "Specify dataform region when dataform is not available in the default cloud region of choice"
+  type        = string
+  default     = ""
+}
+
 variable "project_owner_email" {
   description = "Email address of the project owner."
   type        = string


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description
Adding precondition validation when resource are not available in the region of choice. 

# How has this been tested?

integration tested.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
