### PR TITLE
Persist activation log tables and prevent terraform destroy

### DIFF
--- a/infrastructure/terraform/modules/activation/main.tf
+++ b/infrastructure/terraform/modules/activation/main.tf
@@ -85,7 +85,7 @@ module "bigquery" {
   description                 = "activation appliction logs"
   project_id                  = var.project_id
   location                    = var.data_location
-  default_table_expiration_ms = 360000000
+  delete_contents_on_destroy  = false
 }
 
 resource "null_resource" "check_artifactregistry_api" {


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description
Removed the default TTL for table in the activation dataset
explicitly prevent deletion of dataset if it's not empty

# How has this been tested?
Tested in integration environment

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
