### PR TITLE
Multi stream activation

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -143,7 +143,7 @@ resource "null_resource" "poetry_install" {
 }
 
 data "external" "check_ga4_property_type" {
-  program     = ["bash", "-c", "${local.poetry_run_alias} ga4-setup --ga4_resource=check_property_type --ga4_property_id=${var.ga4_property_id} --ga4_stream_id=${var.ga4_stream_id}"]
+  program     = ["bash", "-c", "${local.poetry_run_alias} ga4-setup --ga4_resource=check_property_type --ga4_property_id=${var.ga4_property_id}"]
   working_dir = local.source_root_dir
   depends_on  = [null_resource.poetry_install]
 }

--- a/infrastructure/terraform/modules/activation/export-procedures.tf
+++ b/infrastructure/terraform/modules/activation/export-procedures.tf
@@ -15,7 +15,7 @@
 data "template_file" "purchase_propensity_csv_export_query" {
   template = file("${local.source_root_dir}/templates/activation_user_import/purchase_propensity_csv_export.sqlx")
   vars = {
-    ga4_stream_id = var.ga4_stream_id
+    ga4_stream_id = var.ga4_stream_id.0
     export_bucket = module.pipeline_bucket.name
   }
 }
@@ -38,7 +38,7 @@ resource "google_bigquery_routine" "export_purchase_propensity_procedure" {
 data "template_file" "cltv_csv_export_query" {
   template = file("${local.source_root_dir}/templates/activation_user_import/cltv_csv_export.sqlx")
   vars = {
-    ga4_stream_id = var.ga4_stream_id
+    ga4_stream_id = var.ga4_stream_id.0
     export_bucket = module.pipeline_bucket.name
   }
 }
@@ -61,7 +61,7 @@ resource "google_bigquery_routine" "export_cltv_procedure" {
 data "template_file" "audience_segmentation_csv_export_query" {
   template = file("${local.source_root_dir}/templates/activation_user_import/audience_segmentation_csv_export.sqlx")
   vars = {
-    ga4_stream_id = var.ga4_stream_id
+    ga4_stream_id = var.ga4_stream_id.0
     export_bucket = module.pipeline_bucket.name
   }
 }
@@ -84,7 +84,7 @@ resource "google_bigquery_routine" "export_audience_segmentation_procedure" {
 data "template_file" "auto_audience_segmentation_csv_export_query" {
   template = file("${local.source_root_dir}/templates/activation_user_import/auto_audience_segmentation_csv_export.sqlx")
   vars = {
-    ga4_stream_id = var.ga4_stream_id
+    ga4_stream_id = var.ga4_stream_id.0
     export_bucket = module.pipeline_bucket.name
   }
 }
@@ -107,7 +107,7 @@ resource "google_bigquery_routine" "export_auto_audience_segmentation_procedure"
 data "template_file" "churn_propensity_csv_export_query" {
   template = file("${local.source_root_dir}/templates/activation_user_import/churn_propensity_csv_export.sqlx")
   vars = {
-    ga4_stream_id = var.ga4_stream_id
+    ga4_stream_id = var.ga4_stream_id.0
     export_bucket = module.pipeline_bucket.name
   }
 }

--- a/infrastructure/terraform/modules/activation/main.tf
+++ b/infrastructure/terraform/modules/activation/main.tf
@@ -408,6 +408,7 @@ data "external" "ga4_measurement_properties" {
   ]
 }
 
+# This module stores the values ga4-measurement-id and ga4-measurement-secret for each data stream in Google Cloud Secret Manager.
 module "data_stream_secrets" {
   source     = "GoogleCloudPlatform/secret-manager/google"
   version    = "~> 0.1"
@@ -422,43 +423,6 @@ module "data_stream_secrets" {
           "measurement-secret" = data.external.ga4_measurement_properties[stream].result["measurement_secret"]
         }
       )
-      automatic_replication = true
-    }
-  ]
-
-  depends_on = [
-    data.external.ga4_measurement_properties
-  ]
-}
-
-# This module stores the values ga4-measurement-id and ga4-measurement-secret in Google Cloud Secret Manager.
-module "secret_manager_measurement_id" {
-  source     = "GoogleCloudPlatform/secret-manager/google"
-  version    = "~> 0.1"
-  project_id = null_resource.check_secretmanager_api.id != "" ? module.project_services.project_id : var.project_id
-  secrets = [
-    for stream in toset(var.ga4_stream_id) :
-    {
-      name                  = "ga4-measurement-id-${stream}"
-      secret_data           = data.external.ga4_measurement_properties[stream].result["measurement_id"]
-      automatic_replication = true
-    }
-  ]
-
-  depends_on = [
-    data.external.ga4_measurement_properties
-  ]
-}
-
-module "secret_manager_measurement_secret" {
-  source     = "GoogleCloudPlatform/secret-manager/google"
-  version    = "~> 0.1"
-  project_id = null_resource.check_secretmanager_api.id != "" ? module.project_services.project_id : var.project_id
-  secrets = [
-    for stream in toset(var.ga4_stream_id) :
-    {
-      name                  = "ga4-measurement-secret-${stream}"
-      secret_data           = data.external.ga4_measurement_properties[stream].result["measurement_secret"]
       automatic_replication = true
     }
   ]

--- a/infrastructure/terraform/modules/activation/variables.tf
+++ b/infrastructure/terraform/modules/activation/variables.tf
@@ -68,8 +68,8 @@ variable "ga4_property_id" {
 }
 
 variable "ga4_stream_id" {
-  description = "Google Analytics data stream id"
-  type        = string
+  description = "Google Analytics data stream id:s for activation"
+  type        = list(string)
 }
 
 variable "poetry_installed" {

--- a/infrastructure/terraform/terraform-sample.tfvars
+++ b/infrastructure/terraform/terraform-sample.tfvars
@@ -52,7 +52,7 @@ activation_project_id        = "Project ID where activation resources will be cr
 ####################  GA4 VARIABLES  #################################
 
 ga4_property_id              = "Google Analytics property id"
-ga4_stream_id                = "Google Analytics data stream id"
+ga4_stream_id                = ["Google Analytics data stream id:s"]
 ga4_measurement_id           = "Google Analytics measurement id"
 ga4_measurement_secret       = "Google Analytics measurement secret"
 

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -172,7 +172,7 @@ variable "ga4_property_id" {
 
 variable "ga4_stream_id" {
   description = "Google Analytics data stream id"
-  type        = string
+  type        = list(string)
 }
 
 variable "ga4_measurement_id" {

--- a/python/activation/main.py
+++ b/python/activation/main.py
@@ -119,6 +119,12 @@ class ActivationOptions(GoogleCloudOptions):
       help='GCS path to the configuration file all activation types',
       required=True
     )
+    parser.add_argument(
+      '--ga4_data_stream_id',
+      type=str,
+      help='Data stream for activation',
+      required=True
+    )
 
 
 

--- a/python/activation/main.py
+++ b/python/activation/main.py
@@ -141,7 +141,8 @@ def build_query(args, activation_type_configuration):
     The query to be used to retrieve data from the source table.
   """
   return activation_type_configuration['source_query_template'].render(
-    source_table=args.source_table
+    source_table=args.source_table,
+    ga4_data_stream_id=args.ga4_data_stream_id
   )
 
 

--- a/python/activation/metadata.json
+++ b/python/activation/metadata.json
@@ -28,6 +28,11 @@
       "helpText": "Pipeline temporary storage location."
     },
     {
+      "name": "ga4_data_stream_id",
+      "label": "Data Stream ID",
+      "helpText": "Data stream for activation."
+    },
+    {
       "name": "ga4_measurement_id",
       "label": "Measurement Protocol ID",
       "helpText": "Measurement ID in GA4."

--- a/python/function/trigger_activation/main.py
+++ b/python/function/trigger_activation/main.py
@@ -45,10 +45,6 @@ def subscribe(cloud_event):
   region = os.environ.get('ACTIVATION_REGION')
   # TEMPLATE_FILE_GCS_LOCATION: The Google Cloud Storage location of the Dataflow Flex Template file.
   template_file_gcs_location = os.environ.get('TEMPLATE_FILE_GCS_LOCATION')
-  # GA4_MEASUREMENT_ID: The Google Analytics 4 measurement ID.
-  ga4_measurement_id = os.environ.get('GA4_MEASUREMENT_ID')
-  # GA4_MEASUREMENT_SECRET: The Google Analytics 4 measurement secret.
-  ga4_measurement_secret = os.environ.get('GA4_MEASUREMENT_SECRET')
   # ACTIVATION_TYPE_CONFIGURATION: The path to a JSON file containing the configuration for the activation type.
   activation_type_configuration = os.environ.get('ACTIVATION_TYPE_CONFIGURATION')
   # PIPELINE_TEMP_LOCATION: The Google Cloud Storage location for temporary files used by the Dataflow Flex Template.
@@ -57,46 +53,52 @@ def subscribe(cloud_event):
   log_db_dataset = os.environ.get('LOG_DATA_SET')
   # PIPELINE_WORKER_EMAIL: The service account email used by the Dataflow Flex Template workers.
   service_account_email = os.environ.get('PIPELINE_WORKER_EMAIL')
+  # The datastreams used for activation
+  ga4_data_streams = os.environ.get('GA4_DATA_STREAMS').split(',')
 
-  # Decodes the base64 encoded data in the message and parses it as JSON.
-  # It then extracts the activation_type and source_table values from the JSON object.
-  message_data = base64.b64decode(cloud_event.data["message"]["data"]).decode()
-  message_obj = json.loads(message_data)
+  for ga4_data_stream_id in ga4_data_streams:
+    ga4_data_stream_config = json.loads(os.environ.get(f'GA4_DATA_STREAM_{ga4_data_stream_id}'))
 
-  activation_type = message_obj['activation_type']
-  source_table = message_obj['source_table']
+    # Decodes the base64 encoded data in the message and parses it as JSON.
+    # It then extracts the activation_type and source_table values from the JSON object.
+    message_data = base64.b64decode(cloud_event.data["message"]["data"]).decode()
+    message_obj = json.loads(message_data)
 
-  # Creates a FlexTemplateRuntimeEnvironment object with the service account email.
-  environment_param = dataflow_v1beta3.FlexTemplateRuntimeEnvironment(service_account_email=service_account_email)
+    activation_type = message_obj['activation_type']
+    source_table = message_obj['source_table']
 
-  # It then creates a dictionary of parameters for the Dataflow Flex Template, including the project ID, activation type, 
-  # activation type configuration, source table, temporary location, GA4 measurement ID, GA4 measurement secret, and log dataset.
-  # Finally, it creates a LaunchFlexTemplateParameter object with the job name, container spec GCS path, environment, and parameters.
-  parameters = {
-    'project': project_id,
-    'activation_type': activation_type,
-    'activation_type_configuration': activation_type_configuration,
-    'source_table': source_table,
-    'temp_location': temp_location,
-    'ga4_measurement_id': ga4_measurement_id,
-    'ga4_api_secret': ga4_measurement_secret,
-    'log_db_dataset': log_db_dataset
-  }
-  flex_template_param = dataflow_v1beta3.LaunchFlexTemplateParameter(
-    job_name=f"activation-pipeline-{activation_type.replace('_','-')}-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
-    container_spec_gcs_path=template_file_gcs_location,
-    environment=environment_param,
-    parameters=parameters
-  )
+    # Creates a FlexTemplateRuntimeEnvironment object with the service account email.
+    environment_param = dataflow_v1beta3.FlexTemplateRuntimeEnvironment(service_account_email=service_account_email)
 
-  # Creates a LaunchFlexTemplateRequest object with the project ID, region, and launch parameter.
-  # It then uses the FlexTemplatesServiceClient to launch the Dataflow Flex Template.
-  request = dataflow_v1beta3.LaunchFlexTemplateRequest(
-    project_id=project_id,
-    location=region,
-    launch_parameter=flex_template_param
-  )
-  client = dataflow_v1beta3.FlexTemplatesServiceClient(client_info=ClientInfo(user_agent=USER_AGENT_ACTIVATION))
-  response = client.launch_flex_template(request=request)
+    # It then creates a dictionary of parameters for the Dataflow Flex Template, including the project ID, activation type,q
+    # activation type configuration, source table, temporary location, GA4 measurement ID, GA4 measurement secret, and log dataset.
+    # Finally, it creates a LaunchFlexTemplateParameter object with the job name, container spec GCS path, environment, and parameters.
+    parameters = {
+      'project': project_id,
+      'activation_type': activation_type,
+      'activation_type_configuration': activation_type_configuration,
+      'source_table': source_table,
+      'temp_location': temp_location,
+      'ga4_data_stream_id': ga4_data_stream_id,
+      'ga4_measurement_id': ga4_data_stream_config['measurement-id'],
+      'ga4_api_secret': ga4_data_stream_config['measurement-secret'],
+      'log_db_dataset': log_db_dataset
+    }
+    flex_template_param = dataflow_v1beta3.LaunchFlexTemplateParameter(
+      job_name=f"activation-pipeline-{activation_type.replace('_','-')}-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
+      container_spec_gcs_path=template_file_gcs_location,
+      environment=environment_param,
+      parameters=parameters
+    )
 
-  print(response)
+    # Creates a LaunchFlexTemplateRequest object with the project ID, region, and launch parameter.
+    # It then uses the FlexTemplatesServiceClient to launch the Dataflow Flex Template.
+    request = dataflow_v1beta3.LaunchFlexTemplateRequest(
+      project_id=project_id,
+      location=region,
+      launch_parameter=flex_template_param
+    )
+    client = dataflow_v1beta3.FlexTemplatesServiceClient(client_info=ClientInfo(user_agent=USER_AGENT_ACTIVATION))
+    response = client.launch_flex_template(request=request)
+
+    print(response)

--- a/python/ga4_setup/setup.py
+++ b/python/ga4_setup/setup.py
@@ -494,13 +494,15 @@ def entry():
   parser = argparse.ArgumentParser()
   parser.add_argument('--ga4_resource', type=str, required=True)
   parser.add_argument('--ga4_property_id', type=str, required=True)
-  parser.add_argument('--ga4_stream_id', type=str, required=True)
+  parser.add_argument('--ga4_stream_id', type=str)
   args = parser.parse_args()
 
   configuration = {
     'property_id': args.ga4_property_id,
-    'stream_id': args.ga4_stream_id
   }
+
+  if args.ga4_stream_id:
+    configuration['stream_id'] = args.ga4_stream_id
 
   # python setup.py --ga4_resource=measurement_properties
   if args.ga4_resource == "measurement_properties":

--- a/templates/activation_query/audience_segmentation_query_template.sqlx
+++ b/templates/activation_query/audience_segmentation_query_template.sqlx
@@ -8,6 +8,7 @@ FROM
   `${mds_project_id}.marketing_ga4_v1_${mds_dataset_suffix}.latest_event_per_user_last_72_hours` b,
   `{{source_table}}` a
 WHERE
-  COALESCE(a.user_id, "") = COALESCE(b.user_id, "")
+  b.stream_id = '{{ga4_data_stream_id}}'
+  AND COALESCE(a.user_id, "") = COALESCE(b.user_id, "")
   AND a.user_pseudo_id = b.user_pseudo_id
   AND a.prediction IS NOT NULL

--- a/templates/activation_query/auto_audience_segmentation_query_template.sqlx
+++ b/templates/activation_query/auto_audience_segmentation_query_template.sqlx
@@ -8,5 +8,6 @@ FROM
   `${mds_project_id}.marketing_ga4_v1_${mds_dataset_suffix}.latest_event_per_user_last_72_hours` b,
   `{{source_table}}` a
 WHERE
-  a.user_id = b.user_pseudo_id
+  b.stream_id = '{{ga4_data_stream_id}}'
+  AND a.user_id = b.user_pseudo_id
   AND a.prediction IS NOT NULL

--- a/templates/activation_query/churn_propensity_query_template.sqlx
+++ b/templates/activation_query/churn_propensity_query_template.sqlx
@@ -9,5 +9,6 @@ FROM
   `${mds_project_id}.marketing_ga4_v1_${mds_dataset_suffix}.latest_event_per_user_last_72_hours` b,
   `{{source_table}}` a
 WHERE
-  COALESCE(a.user_id, "") = COALESCE(b.user_id, "")
+  b.stream_id = '{{ga4_data_stream_id}}'
+  AND COALESCE(a.user_id, "") = COALESCE(b.user_id, "")
   AND a.user_pseudo_id = b.user_pseudo_id

--- a/templates/activation_query/cltv_query_template.sqlx
+++ b/templates/activation_query/cltv_query_template.sqlx
@@ -8,5 +8,6 @@ FROM
   `${mds_project_id}.marketing_ga4_v1_${mds_dataset_suffix}.latest_event_per_user_last_72_hours` b,
   `{{source_table}}` a
 WHERE
-  a.user_pseudo_id = b.user_pseudo_id
+  b.stream_id = '{{ga4_data_stream_id}}'
+  AND a.user_pseudo_id = b.user_pseudo_id
   AND a.prediction > 0

--- a/templates/activation_query/purchase_propensity_query_template.sqlx
+++ b/templates/activation_query/purchase_propensity_query_template.sqlx
@@ -9,5 +9,6 @@ FROM
   `${mds_project_id}.marketing_ga4_v1_${mds_dataset_suffix}.latest_event_per_user_last_72_hours` b,
   `{{source_table}}` a
 WHERE
-  COALESCE(a.user_id, "") = COALESCE(b.user_id, "")
+  b.stream_id = '{{ga4_data_stream_id}}'
+  AND COALESCE(a.user_id, "") = COALESCE(b.user_id, "")
   AND a.user_pseudo_id = b.user_pseudo_id


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Changing the ga4_stream_id to array in order to configure multiple data streams for activation,
Input each activation pipeline with a stream_id which is used to filter the predictions with the specified stream

need to sync the latest version of the public dataform repository https://github.com/GoogleCloudPlatform/marketing-analytics-jumpstart-dataform into you private dataform respository

# How has this been tested?

integration environment

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
