### PR TITLE
Add support for changing time zone via variables

### DIFF
--- a/config/config.yaml.tftpl
+++ b/config/config.yaml.tftpl
@@ -184,7 +184,7 @@ vertex_ai:
         schedule:
           # The `cron` is the cron schedule. Make sure you review the TZ=America/New_York timezone.
           # More information can be found at https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules.
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           # The `max_concurrent_run_count` defines the maximum number of concurrent pipeline runs.
           max_concurrent_run_count: 1
           start_time: null
@@ -268,7 +268,7 @@ vertex_ai:
         schedule:
           # The `cron` is the cron schedule. Make sure you review the TZ=America/New_York timezone.
           # More information can be found at https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules.
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           # The `max_concurrent_run_count` defines the maximum number of concurrent pipeline runs.
           max_concurrent_run_count: 1
           start_time: null
@@ -332,7 +332,7 @@ vertex_ai:
         # `type` must be "custom", when we're building Python and/or SQL based pipelines for feature engineering purposes.
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           # Define the maximum number of concurrent pipeline runs.
           # The default value is 1.
           max_concurrent_run_count: 1
@@ -395,7 +395,7 @@ vertex_ai:
         # `type` must be "custom", when we're building Python and/or SQL based pipelines for feature engineering purposes.
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           # Define the maximum number of concurrent pipeline runs.
           # The default value is 1.
           max_concurrent_run_count: 1
@@ -452,7 +452,7 @@ vertex_ai:
         # `type` must be "custom", when we're building Python and/or SQL based pipelines for feature engineering purposes.
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           # Define the maximum number of concurrent pipeline runs.
           # The default value is 1.
           max_concurrent_run_count: 1
@@ -515,7 +515,7 @@ vertex_ai:
         type: "custom"
         schedule:
           # The cron string is
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           # Define the maximum concurrent run count of the pipeline.
           # The default value is 1.
           max_concurrent_run_count: 1
@@ -565,7 +565,7 @@ vertex_ai:
         type: "tabular-workflows"
         schedule:
           # define the schedule for the pipeline
-          cron: "TZ=America/New_York 0 1 * * *"
+          cron: "TZ=${time_zone} 0 1 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -648,7 +648,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 5 * * *"
+          cron: "TZ=${time_zone} 0 5 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -695,7 +695,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "tabular-workflows"
         schedule:
-          cron: "TZ=America/New_York 0 8 * * SAT"
+          cron: "TZ=${time_zone} 0 8 * * SAT"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -798,7 +798,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 5 * * *"
+          cron: "TZ=${time_zone} 0 5 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -861,7 +861,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "tabular-workflows"
         schedule:
-          cron: "TZ=America/New_York 0 8 * * SAT"
+          cron: "TZ=${time_zone} 0 8 * * SAT"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -964,7 +964,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 5 * * *"
+          cron: "TZ=${time_zone} 0 5 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1027,7 +1027,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 12 * * SAT"
+          cron: "TZ=${time_zone} 0 12 * * SAT"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1078,7 +1078,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 7 * * *"
+          cron: "TZ=${time_zone} 0 7 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1132,7 +1132,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 12 * * SAT"
+          cron: "TZ=${time_zone} 0 12 * * SAT"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1182,7 +1182,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 7 * * *"
+          cron: "TZ=${time_zone} 0 7 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1239,7 +1239,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "tabular-workflows"
         schedule:
-          cron: "TZ=America/New_York 0 16 * * SAT"
+          cron: "TZ=${time_zone} 0 16 * * SAT"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1358,7 +1358,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "tabular-workflows"
         schedule:
-          cron: "TZ=America/New_York 0 20 * * SAT"
+          cron: "TZ=${time_zone} 0 20 * * SAT"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1454,7 +1454,7 @@ vertex_ai:
         #  For using Vertex AI Tabular Workflow use the later, for all other modeling approaches use "custom" (i.e. BQML, Scikit-learn).
         type: "custom"
         schedule:
-          cron: "TZ=America/New_York 0 6 * * *"
+          cron: "TZ=${time_zone} 0 6 * * *"
           max_concurrent_run_count: 1
           start_time: null
           end_time: null
@@ -1540,7 +1540,7 @@ vertex_ai:
         schedule:
           # The `cron` is the cron schedule. Make sure you review the TZ=America/New_York timezone.
           # More information can be found at https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules.
-          cron: "TZ=America/New_York 0 8-23/2 * * *"
+          cron: "TZ=${time_zone} 0 8-23/2 * * *"
           # The `max_concurrent_run_count` defines the maximum number of concurrent pipeline runs.
           max_concurrent_run_count: 1
           start_time: null
@@ -1604,7 +1604,7 @@ vertex_ai:
         schedule:
           # The `cron` is the cron schedule. Make sure you review the TZ=America/New_York timezone.
           # More information can be found at https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules.
-          cron: "TZ=America/New_York 0 8 * * *"
+          cron: "TZ=${time_zone} 0 8 * * *"
           # The `max_concurrent_run_count` defines the maximum number of concurrent pipeline runs.
           max_concurrent_run_count: 1
           start_time: null

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -122,7 +122,8 @@ resource "local_file" "feature_store_configuration" {
     pipelines_github_owner = var.pipelines_github_owner
     pipelines_github_repo  = var.pipelines_github_repo
     #    TODO: this needs to be specific to environment.
-    location = var.destination_data_location
+    location  = var.destination_data_location
+    time_zone = var.time_zone
   })
 }
 
@@ -374,6 +375,9 @@ module "data_store" {
   # The project_owner_email is set in the terraform.tfvars file. 
   # An example of a valid email address is "william.mckinley@my-own-personal-domain.com".
   project_owner_email = var.project_owner_email
+
+  # Set the time zone for the scheduled jobs
+  time_zone = var.time_zone
 }
 
 

--- a/infrastructure/terraform/modules/data-store/main.tf
+++ b/infrastructure/terraform/modules/data-store/main.tf
@@ -62,6 +62,7 @@ module "dataform-workflow-dev" {
   # https://support.google.com/analytics/answer/9358801?hl=en#:~:text=A%20full%20export%20of%20data,(see%20Streaming%20export%20below).
   # Check https://crontab.guru/#0_5-23/4_*_*_* to see next execution times.
   daily_schedule = "0 5-23/4 * * *"
+  time_zone      = var.time_zone
 }
 
 # This module sets up a Dataform workflow environment for the "staging" environment. 
@@ -96,6 +97,7 @@ module "dataform-workflow-staging" {
   # https://support.google.com/analytics/answer/9358801?hl=en#:~:text=A%20full%20export%20of%20data,(see%20Streaming%20export%20below).
   # Check https://crontab.guru/#0_5-23/4_*_*_* to see next execution times.
   daily_schedule = "0 5-23/4 * * *"
+  time_zone      = var.time_zone
 }
 
 # This module sets up a Dataform workflow environment for the "prod" environment. 
@@ -127,4 +129,5 @@ module "dataform-workflow-prod" {
   # https://support.google.com/analytics/answer/9358801?hl=en#:~:text=A%20full%20export%20of%20data,(see%20Streaming%20export%20below).
   # Check https://crontab.guru/#0_5-23/2_*_*_* to see next execution times.
   daily_schedule = "0 5-23/2 * * *"
+  time_zone      = var.time_zone
 }

--- a/infrastructure/terraform/modules/data-store/variables.tf
+++ b/infrastructure/terraform/modules/data-store/variables.tf
@@ -129,3 +129,7 @@ variable "dataform_region" {
   description = "Specify dataform region when dataform is not available in the default cloud region of choice"
   type        = string
 }
+
+variable "time_zone" {
+  type = string
+}

--- a/infrastructure/terraform/modules/dataform-workflow/scheduler.tf
+++ b/infrastructure/terraform/modules/dataform-workflow/scheduler.tf
@@ -19,7 +19,7 @@ resource "google_cloud_scheduler_job" "daily-dataform-increments" {
   description = "Daily Dataform ${var.environment} environment incremental update"
   # The schedule attribute specifies the schedule for the job. In this case, the job is scheduled to run daily at the specified times.
   schedule  = var.daily_schedule
-  time_zone = "America/New_York"
+  time_zone = var.time_zone
   # The attempt_deadline attribute specifies the maximum amount of time that the job will attempt to run before failing.
   # In this case, the job will attempt to run for a maximum of 5 minutes before failing.
   attempt_deadline = "320s"

--- a/infrastructure/terraform/modules/dataform-workflow/variables.tf
+++ b/infrastructure/terraform/modules/dataform-workflow/variables.tf
@@ -75,3 +75,7 @@ variable "includedTags" {
   type    = list(string)
   default = []
 }
+
+variable "time_zone" {
+  type = string
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -241,3 +241,9 @@ variable "website_url" {
   type        = string
   default     = null
 }
+
+variable "time_zone" {
+  description = "Timezone for scheduled jobs"
+  type        = string
+  default     = "America/New_York"
+}


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Add support for changing the time zone for the dataform schedule.

# How has this been tested?

Local `terraform apply`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
