### PR TITLE
Restrict regions for GCP Cloud Build support

### DIFF
--- a/infrastructure/terraform/modules/activation/main.tf
+++ b/infrastructure/terraform/modules/activation/main.tf
@@ -60,6 +60,17 @@ locals {
 
   ga4_setup_source_file              = "${local.source_root_dir}/python/ga4_setup/setup.py"
   ga4_setup_source_file_content_hash = filesha512(local.ga4_setup_source_file)
+
+  # GCP Cloud Build is not available in all regions.
+  cloud_build_available_locations = [
+    "us-central1",
+    "us-west2",
+    "europe-west1",
+    "asia-east1",
+    "australia-southeast1",
+    "southamerica-east1"
+  ]
+
 }
 
 data "google_project" "activation_project" {
@@ -301,6 +312,16 @@ resource "null_resource" "check_cloudbuild_api" {
   depends_on = [
     module.project_services
   ]
+
+  # The lifecycle block of the google_artifact_registry_repository resource defines a precondition that 
+  # checks if the specified region is included in the vertex_pipelines_available_locations list. 
+  # If the condition is not met, an error message is displayed and the Terraform configuration will fail.
+  lifecycle {
+    precondition {
+      condition     = contains(local.cloud_build_available_locations, var.location)
+      error_message = "Cloud Build is not available in your default region: ${var.location}.\nSet 'google_default_region' variable to a valid Cloud Build location, see Restricted Regions in https://cloud.google.com/build/docs/locations."
+    }
+  }
 }
 
 # This resource executes gcloud commands to check whether the IAM API is enabled.
@@ -449,13 +470,13 @@ resource "random_id" "random_suffix" {
 # to interact with other Google Cloud services on your behalf.
 resource "google_project_service_identity" "secretmanager_sa" {
   provider = google-beta
-  project = null_resource.check_cloudkms_api.id != "" ? module.project_services.project_id : var.project_id
-  service = "secretmanager.googleapis.com"
+  project  = null_resource.check_cloudkms_api.id != "" ? module.project_services.project_id : var.project_id
+  service  = "secretmanager.googleapis.com"
 }
- # This Key Ring can then be used to store and manage encryption keys for various purposes, 
- # such as encrypting data at rest or protecting secrets.
+# This Key Ring can then be used to store and manage encryption keys for various purposes, 
+# such as encrypting data at rest or protecting secrets.
 resource "google_kms_key_ring" "key_ring_regional" {
-  name     = "key_ring_regional-${random_id.random_suffix.hex}"
+  name = "key_ring_regional-${random_id.random_suffix.hex}"
   # If you want your replicas in other locations, change the location in the var.location variable passed as a parameter to this submodule.
   # if you your replicas stored global, set the location = "global".
   location = var.location
@@ -494,7 +515,7 @@ data "google_iam_policy" "crypto_key_encrypter_decrypter" {
 # in another data source.
 resource "google_kms_crypto_key_iam_policy" "crypto_key" {
   crypto_key_id = google_kms_crypto_key.crypto_key_regional.id
-  policy_data = data.google_iam_policy.crypto_key_encrypter_decrypter.policy_data
+  policy_data   = data.google_iam_policy.crypto_key_encrypter_decrypter.policy_data
 }
 
 # It sets the IAM policy for a KMS Key Ring, granting specific permissions defined 
@@ -530,13 +551,13 @@ module "secret_manager" {
       # If you want your replicas in other locations, uncomment the following lines and add them here.
       # Check this example, as reference: https://github.com/GoogleCloudPlatform/terraform-google-secret-manager/blob/main/examples/multiple/main.tf#L91
       {
-        location = var.location
+        location     = var.location
         kms_key_name = google_kms_crypto_key.crypto_key_regional.id
       }
     ]
     ga4-measurement-secret = [
       {
-        location = var.location
+        location     = var.location
         kms_key_name = google_kms_crypto_key.crypto_key_regional.id
       }
     ]
@@ -823,8 +844,8 @@ module "activation_pipeline_container" {
 
 # This module executes a gcloud command to build a dataflow flex template and uploads it to Dataflow
 module "activation_pipeline_template" {
-  source                = "terraform-google-modules/gcloud/google"
-  version               = "3.5.0"
+  source  = "terraform-google-modules/gcloud/google"
+  version = "3.5.0"
 
   platform         = "linux"
   create_cmd_body  = "dataflow flex-template build --project=${module.project_services.project_id} \"gs://${module.pipeline_bucket.name}/dataflow/templates/${local.activation_container_image_id}.json\" --image \"${local.docker_repo_prefix}/${google_artifact_registry_repository.activation_repository.name}/${local.activation_container_name}:latest\" --sdk-language \"PYTHON\" --metadata-file \"${local.pipeline_source_dir}/metadata.json\""


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Added restriction to region since the Cloud Build need to run in restriction free regions. The list of unrestricted regions are here: https://cloud.google.com/build/docs/locations
The container images are not built if not run from an unrestricted region, with a silent error in one of the local-exec resources.

# How has this been tested?

I did one successful plan with europe-west1 as region, and an expected failed plan with europe-west3 as region, set in terraform.tfvars.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
